### PR TITLE
Fix hyphen issue

### DIFF
--- a/R/get_boxscore.R
+++ b/R/get_boxscore.R
@@ -13,7 +13,7 @@ get_boxscore <- function(game_id) {
 
 	# Grab team names. Away team is always listed first.
 	pagetext <- rvest::html_text(webpage)
-	matchup <- unlist(strsplit(pagetext, "-"))[[1]][1]
+	matchup <- unlist(strsplit(pagetext, " - "))[[1]][1]
 	away_name <- unlist(strsplit(matchup, " vs. "))[1]
 	away_name <- stringr::str_trim(away_name)
 	home_name <- unlist(strsplit(matchup, " vs. "))[2]


### PR DESCRIPTION
added spacing for get_boxscore to fix issue with teams having a hyphen in their name and splitting on that hyphen instead of the one before 'Box Score'