### PR TITLE
Prevents game in progress from being included

### DIFF
--- a/R/season_boxscore.R
+++ b/R/season_boxscore.R
@@ -26,7 +26,7 @@ season_boxscore <- function(team, season = current_season, aggregate = 'average'
   
   ### Team Schedule
   schedule <- get_schedule(team, season)
-  schedule <- dplyr::filter(schedule, date <= Sys.Date())
+  schedule <- dplyr::filter(schedule, date <= Sys.Date() & !is.na(game_id))
   game_ids <- schedule$game_id
   
   ### Team PBP Name


### PR DESCRIPTION
Resolves an error where a game in progress has a game ID of NA, removes any games with an ID of NA from the schedule.

Though it may be better to limit games on the same day from being included.