### PR TITLE
Update get_game_ids.R

### DIFF
--- a/R/get_game_ids.R
+++ b/R/get_game_ids.R
@@ -47,7 +47,7 @@ get_game_ids <- function(team, season = current_season) {
                          'date' = c(played_dates, unplayed_dates)) 
   df_id <- dplyr::mutate(df_id, 'year' = ifelse(grepl('Nov|Dec', date), 
                                                 substring(season, 1, 4),
-                                                paste0('20', substring(season, 6, 7))))
+                                                paste0('20', as.numeric(substring(season, 1, 4)) + 1)))
   df_id <- dplyr::mutate(df_id, 'date' = as.Date(paste(year, date), '%Y %a, %b %d'))
   df_id <- dplyr::arrange(df_id, date)
   


### PR DESCRIPTION
bug in arranging game IDs by date, season argument is only 4 characters, so substring(season,6,7) returns nothing, and the game IDs are not returned in the correct date order, causing game ID links to be incorrect when calling get_schedule